### PR TITLE
hide login and subscription in phase 1

### DIFF
--- a/internal/providers/client-provider.js
+++ b/internal/providers/client-provider.js
@@ -27,6 +27,12 @@ export function ClientProvider({children}) {
                         res.json(),
                     );
 
+                    // skip subscription example in phase1
+                    const subscriptionExampleIndex = fetchedExamples.findIndex(
+                        (example) => example.data.slug === "/subscriptions",
+                    );
+                    delete fetchedExamples[subscriptionExampleIndex];
+
                     setInstalledExamples(
                         fetchedExamples.filter((example) =>
                             fetchedInstalledApps.includes(example.data.orderId - 1),

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,8 +5,6 @@ import {Inter} from "next/font/google";
 
 import "@/styles/globals.css";
 import styles from "@/styles/app.module.css";
-
-import LoginBar from "./members";
 import React, {useEffect} from "react";
 import {PageTitle} from "@/internal/components/ui/page-title";
 import {GlobalLoader} from "@/src/components/global-loader";
@@ -51,7 +49,8 @@ export default function App({Component, pageProps}) {
                                         priority
                                     />
                                 </Link>
-                                <LoginBar/>
+                                {/*Hide login in phase1*/}
+                                {/*<LoginBar/>*/}
                             </header>
                             {pageProps.title && (
                                 <PageTitle title={pageProps.title} withBackButton={true}/>


### PR DESCRIPTION
We want to release quickstart so we decided that in phase 1 we will ignore the login (and thus the subscription) experience and focus on it later on, we just don't want it to be a blocker for quickstart.